### PR TITLE
uri_for encodes query parameters

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -77,7 +77,7 @@ class Router
       value = params[name] ? ''
       delete params[name]
       url = url.replace route_param, value
-    query = qs.stringify params, encode: false
+    query = qs.stringify params, encode: true
     url = url.replace /\/$/, '' if url.length > 1
     url += "?#{query}" if query.length
     url = "#{req.protocol}://#{req.get 'HOST'}#{url}" if full


### PR DESCRIPTION
E.g. `uri_for('route', { email: 'adam+liechty@mail.com' })` should yield `/my-route?adam%2Bliechty%40mail.com`

Otherwise, upon parsing the query string on the other side (e.g. when paired with the `accurized` module for form fields), the `+` is interpreted as an escape for a space, etc.